### PR TITLE
Fixed security vulnerability

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -197,7 +197,6 @@ class Woo_Minecraft {
 			wp_send_json_error( array(
 				'msg'  => __( 'Keys do not match', 'wmc' ),
 				'web'  => $key,
-				'db'   => $key_db,
 				'code' => 3,
 			) );
 		}


### PR DESCRIPTION
Fixed a security vulnerability where the server key would showup in `?woo_minecraft=check&key=SOMEINVALIDKEY` opening a possibility for people to send commands to the Minecraft server trough their own wordpress site (eg. making the player OP)